### PR TITLE
DOC fix install guide link in `00-quickstart.ipynb`

### DIFF
--- a/examples/00-quickstart.ipynb
+++ b/examples/00-quickstart.ipynb
@@ -38,7 +38,7 @@
     "conda install -c conda-forge -c pytorch u8darts-all\n",
     "```\n",
     "\n",
-    "Consult the [detailed install guide](https://github.com/unit8co/darts#installation-guide) if you run into issues or want to install a different flavour (avoiding certain dependencies)."
+    "Consult the [detailed install guide](https://github.com/unit8co/darts/blob/master/INSTALL.md) if you run into issues or want to install a different flavour (avoiding certain dependencies)."
    ]
   },
   {


### PR DESCRIPTION
### Summary

`#installation-guide`  anchor does not exist. With the fix it point to the same target as in:

https://github.com/turbotimon/darts/blob/3a0f1f1474dc6b899daa5e4acc2a60b519794d3b/README.md?plain=1#L63
